### PR TITLE
Adds warnings for System.Security.Cryptography.Xml < 4.4.2

### DIFF
--- a/Content/3.json
+++ b/Content/3.json
@@ -1,0 +1,16 @@
+{
+    "link": "https://github.com/dotnet/announcements/issues/67",
+    "description" : "Microsoft Security Advisory CVE-2018-0765: .NET Core Denial Of Service Vulnerability",
+    "packages" : [
+        {
+            "id" : "System.Security.Cryptography.Xml",
+            "affected" : "4.4.1",
+            "fix" : "4.4.2"
+        },
+        {
+            "id" : "System.Security.Cryptography.Xml",
+            "affected" : "4.4.0",
+            "fix" : "4.4.2"
+        }        
+    ]
+}

--- a/index.json
+++ b/index.json
@@ -1,6 +1,7 @@
 {
 	"links" : [
 		"https://raw.githubusercontent.com/RetireNet/Packages/master/Content/1.json",
-		"https://raw.githubusercontent.com/RetireNet/Packages/master/Content/2.json"
+		"https://raw.githubusercontent.com/RetireNet/Packages/master/Content/2.json",
+		"https://raw.githubusercontent.com/RetireNet/Packages/master/Content/3.json"		
 	]
 }


### PR DESCRIPTION
Solves https://github.com/RetireNet/dotnet-retire/issues/10